### PR TITLE
(BKR-1189) Fix port mapping

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -70,6 +70,17 @@ module Beaker
         container_opts = {
           'Image' => image_name,
           'Hostname' => host.name,
+          'name' => host.name,
+          'HostConfig' => {
+            'PortBindings' => {
+              '22/tcp' => [{ 'HostPort' => rand.to_s[2..5], 'HostIp' => '0.0.0.0'}]
+            },
+            'PublishAllPorts' => true,
+            'Privileged' => true,
+            'RestartPolicy' => {
+              'Name' => 'always'
+            }
+          }
         }
         container = find_container(host)
 
@@ -102,7 +113,7 @@ module Beaker
         fix_ssh(container) if @options[:provision] == false
 
         @logger.debug("Starting container #{container.id}")
-        container.start({"PublishAllPorts" => true, "Privileged" => true})
+        container.start
 
         # Find out where the ssh port is from the container
         # When running on swarm DOCKER_HOST points to the swarm manager so we have to get the

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -180,6 +180,17 @@ module Beaker
           expect( ::Docker::Container ).to receive(:create).with({
             'Image' => image.id,
             'Hostname' => host.name,
+            'name' => host.name,
+            'HostConfig' => {
+              'PortBindings' => {
+                '22/tcp' => [{ 'HostPort' => /\b\d{4}\b/, 'HostIp' => '0.0.0.0'}]
+              },
+              'PublishAllPorts' => true,
+              'Privileged' => true,
+              'RestartPolicy' => {
+                'Name' => 'always'
+              }
+            }
           })
         end
 
@@ -199,6 +210,17 @@ module Beaker
           expect( ::Docker::Container ).to receive(:create).with({
             'Image' => image.id,
             'Hostname' => host.name,
+            'name' => host.name,
+            'HostConfig' => {
+              'PortBindings' => {
+                '22/tcp' => [{ 'HostPort' => /\b\d{4}\b/, 'HostIp' => '0.0.0.0'}]
+              },
+              'PublishAllPorts' => true,
+              'Privileged' => true,
+              'RestartPolicy' => {
+                'Name' => 'always'
+              }
+            }
           })
         end
 
@@ -214,6 +236,16 @@ module Beaker
             'Image' => image.id,
             'Hostname' => host.name,
             'name' => container_name,
+            'HostConfig' => {
+              'PortBindings' => {
+                '22/tcp' => [{ 'HostPort' => /\b\d{4}\b/, 'HostIp' => '0.0.0.0'}]
+              },
+              'PublishAllPorts' => true,
+              'Privileged' => true,
+              'RestartPolicy' => {
+                'Name' => 'always'
+              }
+            }
           })
         end
 
@@ -251,6 +283,7 @@ module Beaker
           expect( ::Docker::Container ).to receive(:create).with({
             'Image' => image.id,
             'Hostname' => host.name,
+            'name' => host.name,
             'HostConfig' => {
               'Binds' => [
                 '/source_folder:/mount_point',
@@ -258,7 +291,15 @@ module Beaker
                 '/different_folder:/different_mount:rw',
                 "#{File.expand_path('./')}:/relative_mount",
                 "#{File.expand_path('local_folder')}:/another_relative_mount",
-              ]
+              ],
+              'PortBindings' => {
+                '22/tcp' => [{ 'HostPort' => /\b\d{4}\b/, 'HostIp' => '0.0.0.0'}]
+              },
+              'PublishAllPorts' => true,
+              'Privileged' => true,
+              'RestartPolicy' => {
+                'Name' => 'always'
+              }
             }
           })
         end
@@ -267,7 +308,7 @@ module Beaker
       end
 
       it 'should start the container' do
-        expect( container ).to receive(:start).with({'PublishAllPorts' => true, 'Privileged' => true})
+        expect( container ).to receive(:start)
 
         docker.provision
       end


### PR DESCRIPTION
The port mapping is for port 22 that is used to ssh. This maps a static random 4 digit port when the container is created so a random port is not assigned. 

When a random port is assigned it would change it when the container is restarted and beaker would still be using old port and would not be able to ssh.