### PR TITLE
Don't set container name to node hostname

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -70,7 +70,6 @@ module Beaker
         container_opts = {
           'Image' => image_name,
           'Hostname' => host.name,
-          'name' => host.name,
           'HostConfig' => {
             'PortBindings' => {
               '22/tcp' => [{ 'HostPort' => rand.to_s[2..5], 'HostIp' => '0.0.0.0'}]

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -181,7 +181,6 @@ module Beaker
           expect( ::Docker::Container ).to receive(:create).with({
             'Image' => image.id,
             'Hostname' => host.name,
-            'name' => host.name,
             'HostConfig' => {
               'PortBindings' => {
                 '22/tcp' => [{ 'HostPort' => /\b\d{4}\b/, 'HostIp' => '0.0.0.0'}]
@@ -192,7 +191,7 @@ module Beaker
                 'Name' => 'always'
               }
             }
-          })
+          }).with(hash_excluding('name'))
         end
 
         docker.provision
@@ -211,7 +210,6 @@ module Beaker
           expect( ::Docker::Container ).to receive(:create).with({
             'Image' => image.id,
             'Hostname' => host.name,
-            'name' => host.name,
             'HostConfig' => {
               'PortBindings' => {
                 '22/tcp' => [{ 'HostPort' => /\b\d{4}\b/, 'HostIp' => '0.0.0.0'}]
@@ -222,7 +220,7 @@ module Beaker
                 'Name' => 'always'
               }
             }
-          })
+          }).with(hash_excluding('name'))
         end
 
         docker.provision
@@ -284,7 +282,6 @@ module Beaker
           expect( ::Docker::Container ).to receive(:create).with({
             'Image' => image.id,
             'Hostname' => host.name,
-            'name' => host.name,
             'HostConfig' => {
               'Binds' => [
                 '/source_folder:/mount_point',


### PR DESCRIPTION
As pointed out [here](https://github.com/puppetlabs/beaker-docker/pull/3#discussion_r135492133), PR #3 introduced a regression by setting the container name to the node hostname by default. This prevents running beaker concurrently with other beaker nodesets containing nodes with the same hostname.

This patch simply leaves that option blank by default (pre-PR3 behavior).