### PR TITLE
Fix Archlinux support

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -279,6 +279,7 @@ module Beaker
           EOF
         when /archlinux/
           dockerfile += <<-EOF
+            RUN pacman --noconfirm -Sy archlinux-keyring
             RUN pacman --noconfirm -Syu
             RUN pacman -S --noconfirm openssh #{Beaker::HostPrebuiltSteps::ARCHLINUX_PACKAGES.join(' ')}
             RUN ssh-keygen -A

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -279,7 +279,7 @@ module Beaker
           EOF
         when /archlinux/
           dockerfile += <<-EOF
-            RUN pacman -Sy
+            RUN pacman --noconfirm -Syu
             RUN pacman -S --noconfirm openssh #{Beaker::HostPrebuiltSteps::ARCHLINUX_PACKAGES.join(' ')}
             RUN ssh-keygen -A
             RUN sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config


### PR DESCRIPTION
This fixes a few issues with the official archlinux docker images. The used nodeset:

```yaml
---
HOSTS:
  archlinux-current-x64:
    platform: archlinux-current-amd64
    hypervisor: docker
    image: archlinux/base
    docker_preserve_image: true
    docker_cmd: '["/bin/init"]'
    docker_image_commands:
      - 'pacman --noconfirm -Sy systemd-sysvcompat'
      - 'systemctl mask getty@tty1.service getty-static.service'
      - 'locale-gen en_US.UTF-8'
      - 'echo LANG=en_US.UTF-8 > /etc/locale.conf'
CONFIG:
  trace_limit: 200
  masterless: true
```

The individual commits contain detailed information about the issues.