### PR TITLE
(BKR-305) Support custom docker options

### DIFF
--- a/acceptance/config/nodes/hosts.yaml
+++ b/acceptance/config/nodes/hosts.yaml
@@ -12,6 +12,10 @@ HOSTS:
       - classifier
       - default
     docker_cmd: '["/sbin/init"]'
+    dockeropts:
+      Labels:
+        one: '1'
+        two: '2'
   ubuntu1604-64-2:
     platform: ubuntu-1604-x86_64
     hypervisor: docker
@@ -23,3 +27,7 @@ CONFIG:
   nfs_server: none
   consoleport: 443
   log_level: verbose
+  dockeropts:
+    Labels:
+      one: '3'
+      two: '4'

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -81,6 +81,12 @@ module Beaker
             }
           }
         }
+        if host['dockeropts'] || @options[:dockeropts]
+          dockeropts = host['dockeropts'] ? host['dockeropts'] : @options[:dockeropts]
+          dockeropts.each do |k,v|
+            container_opts[k] = v
+          end
+        end
         container = find_container(host)
 
         # If the specified container exists, then use it rather creating a new one

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -20,7 +20,16 @@ module Beaker
   ]
 
   describe Docker do
-    let(:hosts) { make_hosts }
+    let(:hosts) {
+      the_hosts = make_hosts
+      the_hosts[2]['dockeropts'] = {
+        'Labels' => {
+          'one' => 3,
+          'two' => 4,
+        },
+      }
+      the_hosts
+    }
 
     let(:logger) do
       logger = double('logger')
@@ -35,7 +44,13 @@ module Beaker
     let(:options) {{
       :logger => logger,
       :forward_ssh_agent => true,
-      :provision => true
+      :provision => true,
+      :dockeropts => {
+        'Labels' => {
+          'one' => 1,
+          'two' => 2,
+        },
+      },
     }}
 
     let(:image) do
@@ -65,7 +80,7 @@ module Beaker
             ],
           },
           'Gateway' => '192.0.2.254'
-        },
+        }
       })
       allow( container ).to receive(:kill)
       allow( container ).to receive(:delete)
@@ -191,7 +206,11 @@ module Beaker
               'RestartPolicy' => {
                 'Name' => 'always'
               }
-            }
+            },
+            'Labels' => {
+              'one' => 1,
+              'two' => 2,
+            },
           }).with(hash_excluding('name'))
         end
 
@@ -220,7 +239,11 @@ module Beaker
               'RestartPolicy' => {
                 'Name' => 'always'
               }
-            }
+            },
+            'Labels' => {
+              'one' => 1,
+              'two' => 2,
+            },
           }).with(hash_excluding('name'))
         end
 
@@ -245,7 +268,11 @@ module Beaker
               'RestartPolicy' => {
                 'Name' => 'always'
               }
-            }
+            },
+            'Labels' => {
+              'one' => (index == 2 ? 3 : 1),
+              'two' => (index == 2 ? 4 : 2),
+            },
           })
         end
 
@@ -299,7 +326,11 @@ module Beaker
               'RestartPolicy' => {
                 'Name' => 'always'
               }
-            }
+            },
+            'Labels' => {
+              'one' => (index == 2 ? 3 : 1),
+              'two' => (index == 2 ? 4 : 2),
+            },
           })
         end
 
@@ -323,7 +354,11 @@ module Beaker
                 'Name' => 'always'
               },
               'CapAdd' => ['NET_ADMIN', 'SYS_ADMIN']
-            }
+            },
+            'Labels' => {
+              'one' => (index == 2 ? 3 : 1),
+              'two' => (index == 2 ? 4 : 2),
+            },
           })
         end
 


### PR DESCRIPTION
Allows custom docker options to be set via the container options JSON. Node set wide options can be set under the `config` hash using the `dockeropts` hash. Per host options can be set in each host using the `dockeropts` hash. Per host options override node set options. The `dockeropts` hash is copied into the container options.

An example of an option is `Labels`. A hash can be used to set any number of labels for the containers. For example, to target a specific Docker Swarm collection.