### PR TITLE
(PUP-9212) Allow for building containers with context

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,7 +16,7 @@ end
 # We don't put beaker in as a test dependency because we
 # don't want to create a transitive dependency
 group :acceptance_testing do
-  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 3.0')
+  gem "beaker", *location_for(ENV['BEAKER_VERSION'] || '~> 4.0')
 end
 
 

--- a/docker.md
+++ b/docker.md
@@ -48,6 +48,32 @@ By default the docker container just runs an sshd which is adequate for 'puppet 
     CONFIG:
       type: foss
 
+### Using the entrypoint of an image and not sshd ###
+Instead of using ssh as the CMD for a container, beaker will use the entrypoint already defined if `use_image_entry_point` is used. Beaker will still load ssh onto the container and start it, but ssh will not be the entrypoint for the container. Below is an example of using the puppetserver image.
+
+    HOSTS:
+      puppetserver:
+        platform: ubuntu-1604-x86_64 
+        hypervisor: docker
+        image: puppet/puppetserver-standalone:6.0.1
+        use_image_entry_point: true
+        roles:
+          - master
+    CONFIG:
+      type: foss
+
+### Using dockerfiles with beaker hosts files ###
+Beaker can utilize a dockerfile specified in hosts file; use the `dockerfile` attribute of a host to specify the location of the dockerfile. Beaker will use the directory it is run in to pass as the context for dockerfile DSL commands such as COPY and VOLUME, so make sure the paths are set correctly for the right context.
+
+    HOSTS:
+      ubuntu-12-10:
+        platform: ubuntu-12.10-x64
+        dockerfile: path/to/my/dockerfile
+        hypervisor: docker
+        docker_cmd: '["/sbin/init"]'
+    CONFIG:
+      type: foss
+
 ### Preserve Docker Image ###
 Unless the image configuration changes you might want to keep the Docker image for multiple spec runs. Use `docker_preserve_image` option for a host.
 

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -60,7 +60,13 @@ module Beaker
             # with external build dependencies later.
             if File.exist?(dockerfile)
               dir = File.expand_path(dockerfile).chomp(dockerfile)
-              image = ::Docker::Image.build_from_dir(dir, {'dockerfile' => dockerfile})
+              image = ::Docker::Image.build_from_dir(
+                dir,
+                { 'dockerfile' => dockerfile,
+                  :rm => true,
+                  :buildargs => buildargs_for(host)
+                }
+              )
             else
               raise "Unable to find dockerfile at #{dockerfile}"
             end

--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -50,20 +50,40 @@ module Beaker
       @hosts.each do |host|
         @logger.notify "provisioning #{host.name}"
 
+        container_opts = {}
         @logger.debug("Creating image")
-        unless host['use_image_entry_point']
-          image = ::Docker::Image.build(dockerfile_for(host), {
-             :rm => true, :buildargs => buildargs_for(host)
-          })
-        else
-          df = <<-DF
+          if dockerfile = host['dockerfile']
+            install_and_run_ssh = true
+            container_opts['ExposedPorts'] = {'22/tcp' => {} }
+            # assume that the dockerfile is in the repo and tests are running
+            # from the root of the repo; maybe add support for external Dockerfiles
+            # with external build dependencies later.
+            if File.exist?(dockerfile)
+              dir = File.expand_path(dockerfile).chomp(dockerfile)
+              image = ::Docker::Image.build_from_dir(dir, {'dockerfile' => dockerfile})
+            else
+              raise "Unable to find dockerfile at #{dockerfile}"
+            end
+          elsif host['use_image_entry_point']
+            install_and_run_ssh = true
+            df = <<-DF
             FROM #{host['image']}
             EXPOSE 22
           DF
-          image = ::Docker::Image.build(df, {
-            :rm => true, :buildargs => buildargs_for(host)
+
+            if cmd = host['docker_cmd']
+              df += cmd
+            end
+            image = ::Docker::Image.build(df, {
+              :rm => true, :buildargs => buildargs_for(host)
+            })
+
+          else
+
+          image = ::Docker::Image.build(dockerfile_for(host), {
+             :rm => true, :buildargs => buildargs_for(host)
           })
-        end
+          end
 
         if @docker_type == 'swarm'
           image_name = "#{@registry}/beaker/#{image.id}"
@@ -77,7 +97,7 @@ module Beaker
           image_name = image.id
         end
 
-        container_opts = {
+        container_opts.merge! ( {
           'Image' => image_name,
           'Hostname' => host.name,
           'HostConfig' => {
@@ -90,7 +110,7 @@ module Beaker
               'Name' => 'always'
             }
           }
-        }
+        } )
         if host['dockeropts'] || @options[:dockeropts]
           dockeropts = host['dockeropts'] ? host['dockeropts'] : @options[:dockeropts]
           dockeropts.each do |k,v|
@@ -139,11 +159,11 @@ module Beaker
         @logger.debug("Starting container #{container.id}")
         container.start
 
-        if host['use_image_entry_point']
-          @logger.notify('Installing ssh components and starting ssh daemon in container')
+        if install_and_run_ssh
+          @logger.notify("Installing ssh components and starting ssh daemon in #{host} container")
           install_ssh_components(container, host)
           # run fixssh to configure and start the ssh service
-          fix_ssh(container)
+          fix_ssh(container, host)
         end
         # Find out where the ssh port is from the container
         # When running on swarm DOCKER_HOST points to the swarm manager so we have to get the
@@ -187,8 +207,7 @@ module Beaker
 
     end
 
-    # When using the entrypoint of an image, run this method to download and install ssh
-    # alongside your container's CMD
+    # This sideloads sshd after a container starts
     def install_ssh_components(container, host)
       case host['platform']
       when /ubuntu/, /debian/
@@ -219,6 +238,9 @@ module Beaker
         container.exec(%w(ssh-keygen -A))
         container.exec(%w(sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config))
         container.exec(%w(systemctl enable sshd))
+      when /alpine/
+        container.exec(%w(apk add --update openssh))
+        container.exec(%w(ssh-keygen -A))
       else
         # TODO add more platform steps here
         raise "platform #{host['platform']} not yet supported on docker"
@@ -291,110 +313,100 @@ module Beaker
     end
 
     def dockerfile_for(host)
-      if host['dockerfile'] then
-        @logger.debug("attempting to load user Dockerfile from #{host['dockerfile']}")
-        if File.exist?(host['dockerfile']) then
-          dockerfile = File.read(host['dockerfile'])
-        else
-          raise "requested Dockerfile #{host['dockerfile']} does not exist"
-        end
+      # specify base image
+      dockerfile = <<-EOF
+        FROM #{host['image']}
+        ENV container docker
+      EOF
+
+      # additional options to specify to the sshd
+      # may vary by platform
+      sshd_options = ''
+
+      # add platform-specific actions
+      service_name = "sshd"
+      case host['platform']
+      when /ubuntu/, /debian/
+        service_name = "ssh"
+        dockerfile += <<-EOF
+          RUN apt-get update
+          RUN apt-get install -y openssh-server openssh-client #{Beaker::HostPrebuiltSteps::DEBIAN_PACKAGES.join(' ')}
+        EOF
+        when  /cumulus/
+          dockerfile += <<-EOF
+          RUN apt-get update
+          RUN apt-get install -y openssh-server openssh-client #{Beaker::HostPrebuiltSteps::CUMULUS_PACKAGES.join(' ')}
+        EOF
+      when /fedora-(2[2-9])/
+        dockerfile += <<-EOF
+          RUN dnf clean all
+          RUN dnf install -y sudo openssh-server openssh-clients #{Beaker::HostPrebuiltSteps::UNIX_PACKAGES.join(' ')}
+          RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
+          RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
+        EOF
+      when /^el-/, /centos/, /fedora/, /redhat/, /eos/
+        dockerfile += <<-EOF
+          RUN yum clean all
+          RUN yum install -y sudo openssh-server openssh-clients #{Beaker::HostPrebuiltSteps::UNIX_PACKAGES.join(' ')}
+          RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
+          RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
+        EOF
+      when /opensuse/, /sles/
+        dockerfile += <<-EOF
+          RUN zypper -n in openssh #{Beaker::HostPrebuiltSteps::SLES_PACKAGES.join(' ')}
+          RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
+          RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
+          RUN sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config
+        EOF
+      when /archlinux/
+        dockerfile += <<-EOF
+          RUN pacman --noconfirm -Sy archlinux-keyring
+          RUN pacman --noconfirm -Syu
+          RUN pacman -S --noconfirm openssh #{Beaker::HostPrebuiltSteps::ARCHLINUX_PACKAGES.join(' ')}
+          RUN ssh-keygen -A
+          RUN sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config
+          RUN systemctl enable sshd
+        EOF
       else
-        raise("Docker image undefined!") if (host['image']||= nil).to_s.empty?
-
-        # specify base image
-        dockerfile = <<-EOF
-          FROM #{host['image']}
-          ENV container docker
-        EOF
-
-        # additional options to specify to the sshd
-        # may vary by platform
-        sshd_options = ''
-
-        # add platform-specific actions
-        service_name = "sshd"
-        case host['platform']
-        when /ubuntu/, /debian/
-          service_name = "ssh"
-          dockerfile += <<-EOF
-            RUN apt-get update
-            RUN apt-get install -y openssh-server openssh-client #{Beaker::HostPrebuiltSteps::DEBIAN_PACKAGES.join(' ')}
-          EOF
-          when  /cumulus/
-            dockerfile += <<-EOF
-            RUN apt-get update
-            RUN apt-get install -y openssh-server openssh-client #{Beaker::HostPrebuiltSteps::CUMULUS_PACKAGES.join(' ')}
-          EOF
-        when /fedora-(2[2-9])/
-          dockerfile += <<-EOF
-            RUN dnf clean all
-            RUN dnf install -y sudo openssh-server openssh-clients #{Beaker::HostPrebuiltSteps::UNIX_PACKAGES.join(' ')}
-            RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
-            RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
-          EOF
-        when /^el-/, /centos/, /fedora/, /redhat/, /eos/
-          dockerfile += <<-EOF
-            RUN yum clean all
-            RUN yum install -y sudo openssh-server openssh-clients #{Beaker::HostPrebuiltSteps::UNIX_PACKAGES.join(' ')}
-            RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
-            RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
-          EOF
-        when /opensuse/, /sles/
-          dockerfile += <<-EOF
-            RUN zypper -n in openssh #{Beaker::HostPrebuiltSteps::SLES_PACKAGES.join(' ')}
-            RUN ssh-keygen -t rsa -f /etc/ssh/ssh_host_rsa_key
-            RUN ssh-keygen -t dsa -f /etc/ssh/ssh_host_dsa_key
-            RUN sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config
-          EOF
-        when /archlinux/
-          dockerfile += <<-EOF
-            RUN pacman --noconfirm -Sy archlinux-keyring
-            RUN pacman --noconfirm -Syu
-            RUN pacman -S --noconfirm openssh #{Beaker::HostPrebuiltSteps::ARCHLINUX_PACKAGES.join(' ')}
-            RUN ssh-keygen -A
-            RUN sed -ri 's/^#?UsePAM .*/UsePAM no/' /etc/ssh/sshd_config
-            RUN systemctl enable sshd
-          EOF
-        else
-          # TODO add more platform steps here
-          raise "platform #{host['platform']} not yet supported on docker"
-        end
-
-        # Make sshd directory, set root password
-        dockerfile += <<-EOF
-          RUN mkdir -p /var/run/sshd
-          RUN echo root:#{root_password} | chpasswd
-        EOF
-
-        # Configure sshd service to allowroot login using password
-        # Also, disable reverse DNS lookups to prevent every. single. ssh
-        # operation taking 30 seconds while the lookup times out.
-        dockerfile += <<-EOF
-          RUN sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
-          RUN sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config
-          RUN sed -ri 's/^#?UseDNS .*/UseDNS no/' /etc/ssh/sshd_config
-        EOF
-
-
-        # Any extra commands specified for the host
-        dockerfile += (host['docker_image_commands'] || []).map { |command|
-          "RUN #{command}\n"
-        }.join('')
-
-        # Override image entrypoint
-        if host['docker_image_entrypoint']
-          dockerfile += "ENTRYPOINT #{host['docker_image_entrypoint']}\n"
-        end
-
-        # How to start a sshd on port 22.  May be an init for more supervision
-        # Ensure that the ssh server can be restarted (done from set_env) and container keeps running
-        cmd = host['docker_cmd'] || ["sh","-c","service #{service_name} start ; tail -f /dev/null"]
-        dockerfile += <<-EOF
-          EXPOSE 22
-          CMD #{cmd}
-        EOF
-
+        # TODO add more platform steps here
+        raise "platform #{host['platform']} not yet supported on docker"
       end
+
+      # Make sshd directory, set root password
+      dockerfile += <<-EOF
+        RUN mkdir -p /var/run/sshd
+        RUN echo root:#{root_password} | chpasswd
+      EOF
+
+      # Configure sshd service to allowroot login using password
+      # Also, disable reverse DNS lookups to prevent every. single. ssh
+      # operation taking 30 seconds while the lookup times out.
+      dockerfile += <<-EOF
+        RUN sed -ri 's/^#?PermitRootLogin .*/PermitRootLogin yes/' /etc/ssh/sshd_config
+        RUN sed -ri 's/^#?PasswordAuthentication .*/PasswordAuthentication yes/' /etc/ssh/sshd_config
+        RUN sed -ri 's/^#?UseDNS .*/UseDNS no/' /etc/ssh/sshd_config
+      EOF
+
+
+      # Any extra commands specified for the host
+      dockerfile += (host['docker_image_commands'] || []).map { |command|
+        "RUN #{command}\n"
+      }.join('')
+
+      # Override image entrypoint
+      if host['docker_image_entrypoint']
+        dockerfile += "ENTRYPOINT #{host['docker_image_entrypoint']}\n"
+      end
+
+      # How to start a sshd on port 22.  May be an init for more supervision
+      # Ensure that the ssh server can be restarted (done from set_env) and container keeps running
+      cmd = host['docker_cmd'] || ["sh","-c","service #{service_name} start ; tail -f /dev/null"]
+      dockerfile += <<-EOF
+        EXPOSE 22
+        CMD #{cmd}
+      EOF
+
+    # end
 
       @logger.debug("Dockerfile is #{dockerfile}")
       return dockerfile
@@ -402,7 +414,9 @@ module Beaker
 
     # a puppet run may have changed the ssh config which would
     # keep us out of the container.  This is a best effort to fix it.
-    def fix_ssh(container)
+    # Optionally pass in a host object to to determine which ssh
+    # restart command we should try.
+    def fix_ssh(container, host=nil)
       @logger.debug("Fixing ssh on container #{container.id}")
       container.exec(['sed','-ri',
                       's/^#?PermitRootLogin .*/PermitRootLogin yes/',
@@ -413,7 +427,13 @@ module Beaker
       container.exec(['sed','-ri',
                       's/^#?UseDNS .*/UseDNS no/',
                       '/etc/ssh/sshd_config'])
-      container.exec(%w(service ssh restart))
+      if host
+        if host['platform'] =~ /alpine/
+          container.exec(%w(/usr/sbin/sshd))
+        else
+          container.exec(%w(service ssh restart))
+        end
+      end
     end
 
 

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -216,6 +216,7 @@ module Beaker
       context 'when the host has a "dockerfile" for the host' do
 
         before :each do
+          allow( docker ).to receive(:buildargs_for).and_return('buildargs')
           hosts.each do |host|
             host['dockerfile'] = 'mydockerfile'
           end
@@ -223,7 +224,7 @@ module Beaker
 
         it 'should not call #dockerfile_for but run methods necessary for ssh installation' do
           allow( File ).to receive(:exist?).with('mydockerfile').and_return(true)
-          allow( ::Docker::Image ).to receive(:build_from_dir).and_return(image)
+          allow( ::Docker::Image ).to receive(:build_from_dir).with("/", hash_including(:rm => true, :buildargs => 'buildargs')).and_return(image)
           expect( docker ).not_to receive(:dockerfile_for)
           expect( docker ).to receive(:install_ssh_components).exactly(3).times #once per host
           expect( docker ).to receive(:fix_ssh).exactly(3).times #once per host


### PR DESCRIPTION
Before this commit, beaker-docker would copy the file contents of a
supplied dockerfile and use that to generate a new image. This had the
drawback of not being able to use much of the Dockerfile DSL, such as
COPY or VOLUME, because they were relative paths that were not copied
along with the Dockerfile itself.

This commit changes it so that a dockerfile is copied along with the
context of the test execution directory, so that those Dockerfile DSL
methods are usable with a Dockerfile used by beaker.