### PR TITLE
(BKR-1551) Updates for Beaker 4

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -12,7 +12,7 @@ module Beaker
     def initialize(hosts, options)
       require 'docker'
       @options = options
-      @logger = options[:logger]
+      @logger = options[:logger] || Beaker::Logger.new
       @hosts = hosts
 
       # increase the http timeouts as provisioning images can be slow

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -319,6 +319,7 @@ module Beaker
           container_name = "spec-container-#{index}"
           host['docker_container_name'] = container_name
 
+          allow(::Docker::Container).to receive(:all).and_return([])
           expect( ::Docker::Container ).to receive(:create).with({
             'Image' => image.id,
             'Hostname' => host.name,

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -55,9 +55,8 @@ module Beaker
 
     let(:image) do
       image = double('Docker::Image')
-      allow( image ).to receive(:id)
+      allow( image ).to receive(:id).and_return("zyxwvu")
       allow( image ).to receive(:tag)
-      allow( image ).to receive(:delete)
       image
     end
 
@@ -492,7 +491,7 @@ module Beaker
       it 'should record the image and container for later' do
         docker.provision
 
-        expect( hosts[0]['docker_image'] ).to be === image
+        expect( hosts[0]['docker_image_id'] ).to be === image.id
         expect( hosts[0]['docker_container_id'] ).to be === container.id
       end
 
@@ -534,6 +533,7 @@ module Beaker
         # get into a state where there's something to clean
         allow( ::Docker ).to receive(:validate_version!)
         allow( ::Docker::Container ).to receive(:all).and_return([container])
+        allow( ::Docker::Image ).to receive(:remove).with(image.id)
         allow( docker ).to receive(:dockerfile_for)
         docker.provision
       end
@@ -552,7 +552,7 @@ module Beaker
 
       it 'should delete the images' do
         allow( docker ).to receive( :sleep ).and_return(true)
-        expect( image ).to receive(:delete)
+        expect( ::Docker::Image ).to receive(:remove).with(image.id)
         docker.cleanup
       end
 
@@ -561,7 +561,7 @@ module Beaker
         hosts.each do |host|
           host['docker_preserve_image']=true
         end
-        expect( image ).to_not receive(:delete)
+        expect( ::Docker::Image ).to_not receive(:remove)
         docker.cleanup
       end
 
@@ -570,7 +570,7 @@ module Beaker
         hosts.each do |host|
           host['docker_preserve_image']=false
         end
-        expect( image ).to receive(:delete)
+        expect( ::Docker::Image ).to receive(:remove).with(image.id)
         docker.cleanup
       end
 

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -63,7 +63,7 @@ module Beaker
 
     let(:container) do
       container = double('Docker::Container')
-      allow( container ).to receive(:id)
+      allow( container ).to receive(:id).and_return('abcdef')
       allow( container ).to receive(:start)
       allow( container ).to receive(:info).and_return(
         *(0..2).map { |index| { 'Names' => ["/spec-container-#{index}"] } }
@@ -493,7 +493,7 @@ module Beaker
         docker.provision
 
         expect( hosts[0]['docker_image'] ).to be === image
-        expect( hosts[0]['docker_container'] ).to be === container
+        expect( hosts[0]['docker_container_id'] ).to be === container.id
       end
 
       context 'provision=false' do
@@ -533,6 +533,7 @@ module Beaker
       before :each do
         # get into a state where there's something to clean
         allow( ::Docker ).to receive(:validate_version!)
+        allow( ::Docker::Container ).to receive(:all).and_return([container])
         allow( docker ).to receive(:dockerfile_for)
         docker.provision
       end


### PR DESCRIPTION
Beaker 4's [subcommands](https://github.com/puppetlabs/beaker/blob/master/docs/tutorials/subcommands.md) significantly change how hypervisor methods are called during test runs. Instead of performing the full run with one command, the workflow now looks more like this:

- Run `beaker init --hosts=<hosts-file>` - this creates a `.beaker` folder that contains `subcommand_options.yaml`. This subcommand options file preserves state over the course of subsequent subcommands
- Run `beaker provision`. This creates the SUTs requested in the hosts file, but does not run any tests.
- Run `beaker exec <tests-or-suites>` to run the tests on the SUTs. Repeat if needed.
- Run `beaker destroy` to destroy the SUTs. 

Previously, beaker-docker used `host` objects to store several types of ruby objects for easy access, including a logger, the docker image, and the docker container. https://github.com/puppetlabs/beaker/pull/1557 will stop beaker from writing any `:logger` objects to saved yaml files entirely, and this PR addresses the other issues:
- First commit: instantiate a logger to replace the one that used to come from the host object
- Second commit: stop persisting `host['docker_container']`, and instead persist `host[docker_container_id]` -- use this ID to find the right container via the Docker API instead of expecting a container object to be available already
- Third commit: similarly, stop persisting `host['docker_image']` and persist a `host['docker_image_id']` instead

There are still more ways to improve beaker-docker's behavior when using Beaker subcommands, and I plan to make more PRs to beaker and this repo, but the changes in this PR are allowing me to use beaker-docker with Beaker 4.