### PR TITLE
Allow users with large keyrings to run test

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -444,6 +444,12 @@ module Beaker
       container.exec(['sed','-ri',
                       's/^#?UseDNS .*/UseDNS no/',
                       '/etc/ssh/sshd_config'])
+      # Make sure users with a bunch of SSH keys loaded in their keyring can
+      # still run tests
+      container.exec(['sed','-ri',
+                     's/^#?MaxAuthTries.*/MaxAuthTries 1000/',
+                     '/etc/ssh/sshd_config'])
+
       if host
         if host['platform'] =~ /alpine/
           container.exec(%w(/usr/sbin/sshd))


### PR DESCRIPTION
MaxAuthTries is set too low for users with large keyrings to be able to
successfully execute tests on a local system.