### PR TITLE
BKR-1586 - allow an 'as-is' container to be used rather than rebuilding every time

### DIFF
--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -243,9 +243,9 @@ module Beaker
           expect( docker ).to receive(:fix_ssh).exactly(3).times #once per host
           docker.provision
         end
-      endq
+      end
 
-      it 'should call image create for hosts when use image as is is defined' do
+      it 'should call image create for hosts when use_image_as_is is defined' do
         hosts.each do |host|
           host['use_image_as_is'] = true
           expect( docker ).not_to receive(:install_ssh_components)
@@ -262,7 +262,7 @@ module Beaker
         hosts.each do |host|
           expect( docker ).not_to receive(:install_ssh_components)
           expect( docker ).not_to receive(:fix_ssh)
-          expect( docker ).to receive(:dockerfile_for).with(host).and_return('') unless host = hosts[2]
+          expect( docker ).to receive(:dockerfile_for).with(host).and_return('')
         end
 
         docker.provision

--- a/spec/beaker/hypervisor/docker_spec.rb
+++ b/spec/beaker/hypervisor/docker_spec.rb
@@ -100,6 +100,7 @@ module Beaker
       allow( ::Docker ).to receive(:logger=)
       allow( ::Docker ).to receive(:version).and_return(version)
       allow( ::Docker::Image ).to receive(:build).and_return(image)
+      allow( ::Docker::Image ).to receive(:create).and_return(image)
       allow( ::Docker::Container ).to receive(:create).and_return(container)
       allow_any_instance_of( ::Docker::Container ).to receive(:start)
     end
@@ -242,13 +243,26 @@ module Beaker
           expect( docker ).to receive(:fix_ssh).exactly(3).times #once per host
           docker.provision
         end
+      endq
+
+      it 'should call image create for hosts when use image as is is defined' do
+        hosts.each do |host|
+          host['use_image_as_is'] = true
+          expect( docker ).not_to receive(:install_ssh_components)
+          expect( docker ).not_to receive(:fix_ssh)
+          expect( ::Docker::Image ).to receive(:create).with('fromImage' => host['image']) #once per host
+          expect( ::Docker::Image ).not_to receive(:build)
+          expect( ::Docker::Image ).not_to receive(:build_from_dir)
+        end
+
+        docker.provision
       end
 
       it 'should call dockerfile_for with all the hosts' do
         hosts.each do |host|
           expect( docker ).not_to receive(:install_ssh_components)
           expect( docker ).not_to receive(:fix_ssh)
-          expect( docker ).to receive(:dockerfile_for).with(host).and_return('')
+          expect( docker ).to receive(:dockerfile_for).with(host).and_return('') unless host = hosts[2]
         end
 
         docker.provision


### PR DESCRIPTION
As per https://tickets.puppetlabs.com/browse/BKR-1586 this change allows a new flag to be defined for the docker hypervisor ```use_image_as_is``` which will cause the *provision* step of the process to simply pull the image down and use it without rebuilding it.

This pushes the responsibility for setting up a root:root ssh process on the container onto the user but has the benefit of speeding up test time by only having to do a ```docker pull``` rather than a ```docker build```