### PR TITLE
Fix: Too many authentication failures

### DIFF
--- a/lib/beaker/hypervisor/docker.rb
+++ b/lib/beaker/hypervisor/docker.rb
@@ -224,6 +224,7 @@ module Beaker
           :password => root_password,
           :port => port,
           :forward_agent => forward_ssh_agent,
+          :auth_methods => ['password', 'publickey', 'hostbased', 'keyboard-interactive']
         }
 
         @logger.debug("node available as  ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no root@#{ip} -p #{port}")


### PR DESCRIPTION
By default ssh will try all keys stoered in the ssh agent when
connecting to a server.  If a agent has many keyes loaded it can leed to
the server responding with the following error before the
username/password pair is tried:

  Net::SSH::Disconnect - disconnected: Too many authentication failures

This PR updates the ssh config to use :keys_only which translates to the
ssh confi IdentitiesOnly