### PR TITLE
Fix: docker-api gem dependency

### DIFF
--- a/beaker-docker.gemspec
+++ b/beaker-docker.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   # Run time dependencies
   s.add_runtime_dependency 'stringify-hash', '~> 0.0.0'
-  s.add_runtime_dependency 'docker-api'
+  s.add_runtime_dependency 'docker-api', '< 2.0.0'
 
 end
 


### PR DESCRIPTION
docker-api 2.0.0 removes the validate_version function used here:
lib/beaker/hypervisor/docker.rb