### PR TITLE
Move testing to GH Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby:
+          - "2.4"
+          - "2.5"
+          - "2.6"
+          - "2.7"
+    env:
+      BUNDLE_WITHOUT: release
+    name: Ruby ${{ matrix.ruby }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Run spec tests
+        run: bundle exec rake test:spec
+      # It seems some additonal setup of Docker may be needed for
+      # the acceptance tests to work.
+      # - name: Run acceptance tests
+      #   run: bundle exec rake test:acceptance

--- a/Rakefile
+++ b/Rakefile
@@ -6,14 +6,14 @@ namespace :test do
 
     desc "Run spec tests"
     RSpec::Core::RakeTask.new(:run) do |t|
-      t.rspec_opts = ['--color']
+      t.rspec_opts = ['--color', '--format documentation']
       t.pattern = 'spec/'
     end
 
     desc "Run spec tests with coverage"
     RSpec::Core::RakeTask.new(:coverage) do |t|
       ENV['BEAKER_DOCKER_COVERAGE'] = 'y'
-      t.rspec_opts = ['--color']
+      t.rspec_opts = ['--color', '--format documentation']
       t.pattern = 'spec/'
     end
 


### PR DESCRIPTION
The original testing command in Jenkins was
`bundle exec rspec -fd -c spec`.
This changes moves testing to use the defined tests
in the Rakefile and runs those tests in GH Actions